### PR TITLE
fix(adapter): Allow embedded references

### DIFF
--- a/.changeset/many-walls-count.md
+++ b/.changeset/many-walls-count.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+fix(adapter): Support embedded references

--- a/src/utils/adapterUtils.ts
+++ b/src/utils/adapterUtils.ts
@@ -74,7 +74,11 @@ export interface AdapterUtils {
   ): Record<string, any>
 }
 
-const ownReferences = [ReferenceKind.SCALAR, ReferenceKind.ONE_TO_MANY]
+const ownReferences = [
+  ReferenceKind.SCALAR,
+  ReferenceKind.ONE_TO_MANY,
+  ReferenceKind.EMBEDDED
+]
 
 /**
  * Creates bunch of utilities for adapter
@@ -184,7 +188,10 @@ export function createAdapterUtils(orm: MikroORM): AdapterUtils {
       )
     }
 
-    if (prop.kind === ReferenceKind.SCALAR) {
+    if (
+      prop.kind === ReferenceKind.SCALAR ||
+      prop.kind === ReferenceKind.EMBEDDED
+    ) {
       return [prop.name]
     }
 
@@ -199,7 +206,7 @@ export function createAdapterUtils(orm: MikroORM): AdapterUtils {
     }
 
     createAdapterError(
-      `Cannot normalize "${fieldName}" field name into path for "${metadata.className} entity."`
+      `Cannot normalize "${fieldName}" field name into path for "${metadata.className}" entity.`
     )
   }
 

--- a/tests/fixtures/entities/Address.ts
+++ b/tests/fixtures/entities/Address.ts
@@ -1,0 +1,10 @@
+import {Embeddable, Property} from "@mikro-orm/core"
+
+@Embeddable()
+export class Address {
+  @Property({type: "string"})
+  street!: string
+
+  @Property({type: "string"})
+  city!: string
+}

--- a/tests/fixtures/entities/User.ts
+++ b/tests/fixtures/entities/User.ts
@@ -1,5 +1,7 @@
 import {
   Collection,
+  Embeddable,
+  Embedded,
   Entity,
   OneToMany,
   type Opt,
@@ -25,4 +27,16 @@ export class User extends Base implements DatabaseUser {
 
   @OneToMany(() => Session, "user")
   sessions = new Collection<Session, this>(this)
+
+  @Embedded(() => Address, {object: true})
+  address!: Address
+}
+
+@Embeddable()
+class Address {
+  @Property({type: "string"})
+  street!: string
+
+  @Property({type: "string"})
+  city!: string
 }

--- a/tests/fixtures/entities/User.ts
+++ b/tests/fixtures/entities/User.ts
@@ -1,6 +1,5 @@
 import {
   Collection,
-  Embeddable,
   Embedded,
   Entity,
   OneToMany,
@@ -10,6 +9,7 @@ import {
 } from "@mikro-orm/core"
 import type {User as DatabaseUser} from "better-auth"
 
+import {Address} from "./Address.js"
 import {Base} from "./Base.js"
 import {Session} from "./Session.js"
 
@@ -30,13 +30,4 @@ export class User extends Base implements DatabaseUser {
 
   @Embedded(() => Address, {object: true})
   address!: Address
-}
-
-@Embeddable()
-class Address {
-  @Property({type: "string"})
-  street!: string
-
-  @Property({type: "string"})
-  city!: string
 }

--- a/tests/fixtures/randomUsers.ts
+++ b/tests/fixtures/randomUsers.ts
@@ -35,7 +35,14 @@ export function createRandomUsersUtils(orm: MikroORM): RandomUserUtils {
     const name = [firstName, lastName].join(" ")
     const email = faker.internet.email({firstName, lastName})
 
-    return {email, name}
+    return {
+      email,
+      name,
+      address: {
+        street: faker.location.streetAddress(),
+        city: faker.location.city()
+      }
+    }
   }
 
   const createMany: CreateManyUsers = (amount, cb) =>

--- a/tests/utils/types.ts
+++ b/tests/utils/types.ts
@@ -1,10 +1,12 @@
 export interface UserInput {
   email: string
   name: string
-  address: {
-    street: string
-    city: string
-  }
+  address: AddressInput
+}
+
+export interface AddressInput {
+  street: string
+  city: string
 }
 
 export interface SessionInput {

--- a/tests/utils/types.ts
+++ b/tests/utils/types.ts
@@ -1,6 +1,10 @@
 export interface UserInput {
   email: string
   name: string
+  address: {
+    street: string
+    city: string
+  }
 }
 
 export interface SessionInput {


### PR DESCRIPTION
### Details

Allows using mikro-orm better-auth adapter with a model that has an Embedded / Embeddable reference.

### Changes

- [x] Add Embedded references to the list of ownReferences, so that they can be 'found' by the adapter;
- [ ] Add tests for embedded references via `User.address` field as an example;

### Checklist

- [x] I have self-reviewed my changes before asking for a review from maintainers <!-- Advised. Be sure to review your own changes before asking the maintainers for a review -->
- [x] I have not added changesets 
- [x] I have updated the tests
- [x] ~~I have updated the documentation~~
