### PR TITLE
Ensure referenced entities are in identity map before creating

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,7 @@
     },
     "./package.json": "./package.json"
   },
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "build": "del-cli lib && tsup-node",
     "test": "vitest run",
@@ -77,7 +75,8 @@
     "tsup": "8.4.0",
     "typescript": "5.8.3",
     "uuid": "11.1.0",
-    "vitest": "3.1.1"
+    "vitest": "3.1.1",
+    "deepmerge": "4.3.1"
   },
   "dependencies": {
     "dset": "3.1.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       better-auth:
         specifier: 1.2.9
         version: 1.2.9
+      deepmerge:
+        specifier: 4.3.1
+        version: 4.3.1
       del-cli:
         specifier: 6.0.0
         version: 6.0.0
@@ -956,6 +959,10 @@ packages:
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
+
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
@@ -3073,6 +3080,8 @@ snapshots:
   deep-eql@5.0.2: {}
 
   deep-extend@0.6.0: {}
+
+  deepmerge@4.3.1: {}
 
   defu@6.1.4: {}
 

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -54,7 +54,8 @@ export const mikroOrmAdapter = (
         getFieldPath,
         normalizeInput,
         normalizeOutput,
-        normalizeWhereClauses
+        normalizeWhereClauses,
+        ensureReferencesAreLoaded
       } = createAdapterUtils(orm)
 
       return {
@@ -69,6 +70,8 @@ export const mikroOrmAdapter = (
           ) {
             Reflect.deleteProperty(input, "id")
           }
+
+          ensureReferencesAreLoaded(metadata, input)
 
           const entity = orm.em.create(metadata.class, input)
 

--- a/tests/fixtures/entities/better-auth-adapter-test-fixtures/Address.ts
+++ b/tests/fixtures/entities/better-auth-adapter-test-fixtures/Address.ts
@@ -1,0 +1,10 @@
+import {Embeddable, Property} from "@mikro-orm/core"
+
+@Embeddable()
+export class Address {
+  @Property({type: "string"})
+  street!: string
+
+  @Property({type: "string"})
+  city!: string
+}

--- a/tests/fixtures/entities/better-auth-adapter-test-fixtures/Sessions.ts
+++ b/tests/fixtures/entities/better-auth-adapter-test-fixtures/Sessions.ts
@@ -1,0 +1,24 @@
+import {Entity, ManyToOne, Property, Unique} from "@mikro-orm/core"
+import type {Session as DatabaseSession} from "better-auth"
+
+import {Base} from "../shared/Base.js"
+import {User} from "./User.js"
+
+@Entity()
+export class Sessions extends Base implements Omit<DatabaseSession, "userId"> {
+  @Property({type: "string"})
+  @Unique()
+  token!: string
+
+  @Property({type: Date})
+  expiresAt!: Date
+
+  @Property({type: "string", nullable: true, default: null})
+  ipAddress?: string | null | undefined
+
+  @Property({type: "string", nullable: true, default: null})
+  userAgent?: string | null | undefined
+
+  @ManyToOne(() => User)
+  user!: User
+}

--- a/tests/fixtures/entities/better-auth-adapter-test-fixtures/User.ts
+++ b/tests/fixtures/entities/better-auth-adapter-test-fixtures/User.ts
@@ -1,0 +1,35 @@
+import {
+  Collection,
+  Embedded,
+  Entity,
+  OneToMany,
+  type Opt,
+  Property,
+  Unique
+} from "@mikro-orm/core"
+
+import {Base} from "../shared/Base.js"
+import {Address} from "./Address.js"
+import {Sessions} from "./Sessions.js"
+
+@Entity()
+export class User extends Base {
+  @Property({type: "string"})
+  @Unique()
+  email_address!: string
+
+  @Property({type: "boolean"})
+  emailVerified: Opt<boolean> = false
+
+  @Property({type: "string", nullable: true})
+  test?: string
+
+  @Property({type: "string"})
+  name!: string
+
+  @OneToMany(() => Sessions, "user")
+  sessions = new Collection<Sessions, this>(this)
+
+  @Embedded(() => Address, {object: true, nullable: true})
+  address?: Address
+}

--- a/tests/fixtures/entities/better-auth-entities.ts
+++ b/tests/fixtures/entities/better-auth-entities.ts
@@ -1,0 +1,2 @@
+export {User} from "./better-auth-adapter-test-fixtures/User.js"
+export {Sessions} from "./better-auth-adapter-test-fixtures/Sessions.js"

--- a/tests/fixtures/entities/defaults.ts
+++ b/tests/fixtures/entities/defaults.ts
@@ -1,2 +1,3 @@
 export {User} from "./defaults/User.js"
 export {Session} from "./defaults/Session.js"
+export {Account} from "./defaults/Account.js"

--- a/tests/fixtures/entities/defaults/Account.ts
+++ b/tests/fixtures/entities/defaults/Account.ts
@@ -1,0 +1,37 @@
+import {Entity, ManyToOne, Property} from "@mikro-orm/core"
+import {Base} from "../shared/Base.js"
+import {User} from "./User.js"
+
+@Entity({tableName: "accounts"})
+export class Account extends Base {
+  @ManyToOne(() => User)
+  user!: User
+
+  @Property({type: "string"})
+  accountId!: string // The ID of the account as provided by the SSO or equal to userId for credential accounts
+
+  @Property({type: "string"})
+  providerId!: string // The ID of the oauth provider or 'credential' for email/password
+
+  @Property({nullable: true, type: "string", fieldName: "encrypted_password"})
+  password?: string // The actual hashed password
+
+  // OAuth fields
+  @Property({nullable: true, type: "string"})
+  accessToken?: string
+
+  @Property({nullable: true, type: "string"})
+  refreshToken?: string
+
+  @Property({nullable: true, type: "date"})
+  accessTokenExpiresAt?: Date
+
+  @Property({nullable: true, type: "date"})
+  refreshTokenExpiresAt?: Date
+
+  @Property({nullable: true, type: "string"})
+  scope?: string
+
+  @Property({nullable: true, type: "string"})
+  idToken?: string
+}

--- a/tests/fixtures/orm.ts
+++ b/tests/fixtures/orm.ts
@@ -28,9 +28,10 @@ export function createOrm({entities}: CreateOrmParams): MikroORM {
     allowGlobalContext: true
   })
 
-  beforeAll(async () => await orm.connect())
-
-  beforeEach(async () => await orm.getSchemaGenerator().refreshDatabase())
+  beforeAll(async () => {
+    await orm.connect()
+    await orm.getSchemaGenerator().refreshDatabase()
+  })
 
   afterAll(async () => {
     await orm.close()


### PR DESCRIPTION
### Details

Ensures referenced entities are in the identity map before creating

### Changes

- [ ] Added new util for ensuring references are loaded into mikro-orm's identity map
- [ ] Removed usage of select as better-auth handles this for us
- [ ] Added deepmerge package for merging options in the test
- [ ] Refactored tests to run better-auth provided tests, and some auth flows
- [ ] Added test which fails before this commit, and passes using the new utility function

### Checklist

- [x] I have self-reviewed my changes before asking for a review from maintainers <!-- Advised. Be sure to review your own changes before asking the maintainers for a review -->
- [ ] I have added changesets <!-- Optional. If your PR should trigger a new release, but you can keep this for maintainers -->
- [x] I have brought tests <!-- Can be optional. When you change the code (e.g. code behavior, public or internal API etc.), then include the tests -->
- [ ] I have updated the documentation <!-- Optional, if your changes need to be documented -->
