### PR TITLE
fix(adapter): Remove `orm.em.clear` usage from `updateMany`

### DIFF
--- a/.changeset/long-taxis-act.md
+++ b/.changeset/long-taxis-act.md
@@ -1,0 +1,5 @@
+---
+"better-auth-mikro-orm": patch
+---
+
+Remove `orm.em.clear` usage from `adapter.updateMany`

--- a/tests/node/adapter.test.ts
+++ b/tests/node/adapter.test.ts
@@ -2,7 +2,7 @@ import type {
   Session as DatabaseSession,
   User as DatabaseUser
 } from "better-auth"
-import {BetterAuthError, generateId} from "better-auth"
+import {generateId} from "better-auth"
 import {validate} from "uuid"
 import {expect, suite, test} from "vitest"
 


### PR DESCRIPTION
### Details

This PR applies the same fix from #16 `adapter.updateMany` method.

I don't really like this method, but it least it does not breaks anything. This still may be changed in follow-up updates in the future.

### Changes

- [x] Remove `orm.em.clear` usage from `adapter.updateMany`;

### Checklist

- [x] I have self-reviewed my changes before asking for a review from maintainers <!-- Advised. Be sure to review your own changes before asking the maintainers for a review -->
- [x] I have added changesets <!-- Optional. If your PR should trigger a new release, but you can keep this for maintainers -->
- [x] I have brought tests <!-- Can be optional. When you change the code (e.g. code behavior, public or internal API etc.), then include the tests -->
- [x] ~~I have updated the documentation~~ <!-- Optional, if your changes need to be documented -->
