### PR TITLE
fix(adapter): Use nativeUpdate and nativeDelete methods

### DIFF
--- a/.changeset/cute-regions-wash.md
+++ b/.changeset/cute-regions-wash.md
@@ -1,0 +1,5 @@
+---
+"better-auth-mikro-orm": patch
+---
+
+Use `nativeDelete` and `nativeUpdate` ORM methods for `updateMany`/`deleteMany`. However, this change mean that Identity Map won't be updated after `deleteMany` and `updateMany` methods.

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -145,23 +145,11 @@ export const mikroOrmAdapter = (
         async updateMany({model, where, update}) {
           const metadata = getEntityMetadata(model)
 
-          const rows = await orm.em.find(
+          return orm.em.nativeUpdate(
             metadata.class,
-
             normalizeWhereClauses(metadata, where),
-
-            {
-              fields: ["id"]
-            }
+            normalizeInput(metadata, update as any)
           )
-
-          rows.forEach(entity =>
-            orm.em.assign(entity, normalizeInput(metadata, update as any))
-          )
-
-          await orm.em.flush()
-
-          return rows.length
         },
 
         async delete({model, where}) {
@@ -185,19 +173,10 @@ export const mikroOrmAdapter = (
         async deleteMany({model, where}) {
           const metadata = getEntityMetadata(model)
 
-          const [rows, count] = await orm.em.findAndCount(
+          return orm.em.nativeDelete(
             metadata.class,
-
-            normalizeWhereClauses(metadata, where),
-
-            {
-              fields: ["id"]
-            }
+            normalizeWhereClauses(metadata, where)
           )
-
-          await orm.em.removeAndFlush(rows)
-
-          return count
         }
       }
     }

--- a/tests/node/adapter.test.ts
+++ b/tests/node/adapter.test.ts
@@ -329,7 +329,7 @@ suite("updateMany", () => {
   test("updates matched rows", async () => {
     const [user1, user2, user3] = await randomUsers.createAndFlushMany(3)
 
-    const actual = await adapter.updateMany({
+    const affected = await adapter.updateMany({
       model: "user",
       where: [
         {
@@ -344,12 +344,17 @@ suite("updateMany", () => {
       }
     })
 
-    expect(actual).toBe(2)
-    expect([
-      user1.emailVerified,
-      user2.emailVerified,
-      user3.emailVerified
-    ]).toMatchObject([true, false, true])
+    expect(affected).toBe(2)
+
+    const users = await orm.em.find(entities.User, {
+      id: {$in: [user1.id, user2.id, user3.id]}
+    })
+
+    expect(users.map(({emailVerified}) => emailVerified)).toMatchObject([
+      true,
+      false,
+      true
+    ])
   })
 
   test("does not clear Identity Map", async () => {


### PR DESCRIPTION
### Details

This PR partially reverts #16 and #20, but without manual Identity Map updates.

Closes #15 

### Changes

- [x] Use `orm.em.nativeDelete` in `adapter.deleteMany`;
- [x] Use `orm.em.nativeUpdate` in `adapter.updateMany`;

### Checklist

- [x] I have self-reviewed my changes before asking for a review from maintainers <!-- Advised. Be sure to review your own changes before asking the maintainers for a review -->
- [x] I have added changesets <!-- Optional. If your PR should trigger a new release, but you can keep this for maintainers -->
- [x] I have brought tests <!-- Can be optional. When you change the code (e.g. code behavior, public or internal API etc.), then include the tests -->
- [x] ~~I have updated the documentation~~ <!-- Optional, if your changes need to be documented -->
