### PR TITLE
docs: Better Auth option 'generateId' has changed path

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,15 +8,16 @@
 
 ## Installation
 
-Use the package manager of your choice:
+Using npm:
 ```sh
-# Using npm
 npm i better-auth-mikro-orm
-
-# Using yarn
+```
+Using yarn:
+```sh
 yarn add better-auth-mikro-orm
-
-# Using pnpm
+```
+Using pnpm:
+```sh
 pnpm add better-auth-mikro-orm
 ```
 
@@ -38,9 +39,9 @@ export const auth = betterAuth({
   // Don't forget to disable the ID generator if it is already managed by MikroORM
   advanced: {
     database: {
-      generateId: false,
-    },
-  },
+      generateId: false
+    }
+  }
 })
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # better-auth-mikro-orm
 
-[Mikro ORM](https://mikro-orm.io/) adapter for [Better Auth](https://www.better-auth.com/)
+[MikroORM](https://mikro-orm.io/) adapter for [Better Auth](https://www.better-auth.com/)
 
 
 [![CI](https://github.com/octet-stream/better-auth-mikro-orm/actions/workflows/ci.yaml/badge.svg)](https://github.com/octet-stream/better-auth-mikro-orm/actions/workflows/ci.yaml)
@@ -8,23 +8,23 @@
 
 ## Installation
 
-pnpm:
-
+Use the package manager of your choice:
 ```sh
-pnpm add better-auth-mikro-orm
-```
-
-npm:
-
-```sh
+# Using npm
 npm i better-auth-mikro-orm
+
+# Using yarn
+yarn add better-auth-mikro-orm
+
+# Using pnpm
+pnpm add better-auth-mikro-orm
 ```
 
 ## Usage
 
-1. First you'll need to set up Mikro ORM and define the [core schema](https://www.better-auth.com/docs/concepts/database#core-schema) for Better Auth.
-If you use any plugin - don't forget to check if they have any additional database schema definitions, then define entities you'll need for each plugin.
-2. When you finished with the schema definition you can simply pass the result of `mikroOrmAdapter` call to the `database` option like this:
+1. First you'll need to set up MikroORM and define the [core schema](https://www.better-auth.com/docs/concepts/database#core-schema) for Better Auth.
+If you use any plugin, don't forget to check if they have any additional database schema definitions, then define entities you'll need for each plugin.
+2. When you're finished with the schema definitions, you can simply pass the result of the `mikroOrmAdapter` call to the `database` option like this:
 
 ```ts
 import {mikroOrmAdapter} from "better-auth-mikro-orm"
@@ -35,10 +35,12 @@ import {orm} from "./orm.js" // Your Mikro ORM instance
 export const auth = betterAuth({
   database: mikroOrmAdapter(orm),
 
-  // Don't forget to disable ID generator if it already managed by Mikro ORM:
+  // Don't forget to disable the ID generator if it is already managed by MikroORM
   advanced: {
-    generateId: false
-  }
+    database: {
+      generateId: false,
+    },
+  },
 })
 ```
 
@@ -46,12 +48,12 @@ export const auth = betterAuth({
 
 ### `mikroOrmAdapter(orm: MikroORM): AdapterInstance`
 
-Creates Mikro ORM adapter instance. Note that this adapter **does not** manage database schema for you, so you can't use it with [`@better-auth/cli`](https://www.better-auth.com/docs/concepts/cli).
-This means you'll have to manage database schema on your own.
-Please refer to Better Auth and Mikro ORM documentation on the details.
+Creates the MikroORM adapter instance. Note that this adapter **does not** manage database schemas for you, so you can't use it with [`@better-auth/cli`](https://www.better-auth.com/docs/concepts/cli).
+This means you'll have to manage database schemas on your own.
+Please refer to the Better Auth and MikroORM documentations for details.
 
-Returns `AdapterInstance` function for Better Auth `database` option.
+Returns the `AdapterInstance` function for the Better Auth `database` option.
 
 This function expects a single argument:
 
-* `orm` - An instance of `MikroORM` returned from `MikroORM.init` or `MikroORM.initSync` methods.
+* `orm` - An instance of `MikroORM` returned from either `MikroORM.init` or `MikroORM.initSync`.


### PR DESCRIPTION

### Details

Documentation updated to reflect the new Better Auth path for the `generateId` option, and minor improvements.

### Changes

- [x] Better Auth option `advanced.generateId` has been deprecated in favor of `advanced.database.generateId` (see https://github.com/better-auth/better-auth/blob/52c3fa9af51a784f7166e36f186cf3234d4d0e93/packages/better-auth/src/types/options.ts#L773)
- [x] Fix MikroORM spelling (it does not have a space, see official website)
- [x] Minor English grammar improvements
- [x] Added yarn as a package manager option

### Checklist

- [X] I have updated the documentation <!-- Optional, if your changes need to be documented -->
