### PR TITLE
chore(adapter): Replace deprecated EntityManager.persistAndFlush()

### DIFF
--- a/.changeset/twenty-hounds-eat.md
+++ b/.changeset/twenty-hounds-eat.md
@@ -1,0 +1,5 @@
+---
+"better-auth-mikro-orm": patch
+---
+
+Replace deprecated EntityManager.persistAndFlush()

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -67,7 +67,7 @@ export const mikroOrmAdapter = (
           const input = normalizeInput(metadata, data)
           const entity = orm.em.create(metadata.class, input)
 
-          await orm.em.persistAndFlush(entity)
+          await orm.em.persist(entity).flush()
 
           return normalizeOutput(
             metadata,


### PR DESCRIPTION
## Summary
Replace deprecated MikroORM <code>EntityManager.persistAndFlush()</code> usage in the adapter.

## Why
<code>persistAndFlush()</code> is deprecated. This updates the adapter to the current MikroORM persistence flow without changing the adapter's behavior.

## Change
- replace <code>orm.em.persistAndFlush(entity)</code> with <code>orm.em.persist(entity).flush()</code>

## Testing
- not run
